### PR TITLE
Added XInput link dependency to gainputstatic

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(gainput SHARED ${sources} ${mmsources})
 
 if(WIN32)
 	target_link_libraries(gainput ${XINPUT} ws2_32)
+	target_link_libraries(gainputstatic ${XINPUT} ws2_32)
 	add_definitions(-DGAINPUT_LIB_DYNAMIC=1)
 elseif(ANDROID)
 	target_link_libraries(gainputstatic native_app_glue log android)


### PR DESCRIPTION
I believe that gainputstatic is missing a link dependency to XInput. This CMake change should correct that.
